### PR TITLE
Add module check for ui-router

### DIFF
--- a/ga.js
+++ b/ga.js
@@ -20,11 +20,15 @@ angular.module('ga', [])
         return ga;
     }])
     .run(['$rootScope', '$location', 'ga', function ($rootScope, $location, ga) {
-       
-        $rootScope.$on('$routeChangeStart', function() {
+        // Checks if ui-router is being used or not
+        var stateChange = '$routeChangeStart'
+        try {
+            var uirouter = angular.module('ui.router')
+            stateChange = '$stateChangeSuccess'
+        } catch(e) {}
+        $rootScope.$on(stateChange, function() {
             ga('set', 'page', $location.url());
         });
-
     }])
     /**
       ga="'send', 'event', 'test'" ga-on="click|hover|init"
@@ -46,11 +50,11 @@ angular.module('ga', [])
                     // auto command
                     var href = $element.attr('href');
                     if (href && href === '#') href = '';
-                    var category = $attrs.gaCategory ? $scope.$eval($attrs.gaCategory) : 
+                    var category = $attrs.gaCategory ? $scope.$eval($attrs.gaCategory) :
                             (href && href[0] !== '#' ? (href.match(/\/\//) ? 'link-out' : 'link-in') : 'button'),
-                        action = $attrs.gaAction ? $scope.$eval($attrs.gaAction) : 
+                        action = $attrs.gaAction ? $scope.$eval($attrs.gaAction) :
                             (href ? href : 'click'),
-                        label = $attrs.gaLabel ? $scope.$eval($attrs.gaLabel) : 
+                        label = $attrs.gaLabel ? $scope.$eval($attrs.gaLabel) :
                             ($element[0].title || ($element[0].tagName.match(/input/i) ? $element.attr('value') : $element.text())).substr(0, 64),
                         value = $attrs.gaValue ? $scope.$eval($attrs.gaValue) : null;
                     command = ['send', 'event', category, action, label];


### PR DESCRIPTION
## WHAT
- This PR Adds if clause to detect whether ui-router is being used or not, in order to correctly get data of page change
## WHY
- If ui-router is being used, `$routeChangeStart` is not triggered when changing the page. It prevents sending the data that visitor has changed the page. To fix this, `$stateChangeSuccess` should be caught as well.
